### PR TITLE
[FEAT| Connectivity module

### DIFF
--- a/multiqc_config.yaml
+++ b/multiqc_config.yaml
@@ -40,6 +40,10 @@ tractometry:
 
 # Structural connectivity module configuration
 connectivity:
+  # Optional list of metrics to include (case-insensitive).
+  # Examples: ["fa", "md", "rd", "ad", "commit"]
+  # Set to [] or null to include all detected metrics.
+  metrics: []
   iqr_multiplier: 1.5
 
 # Order that modules should appear in the report

--- a/multiqc_config.yaml
+++ b/multiqc_config.yaml
@@ -38,6 +38,10 @@ tractometry:
   warn_threshold: 90 # Warn if bundle percentage < 90%
   fail_threshold: 80 # Fail if bundle percentage < 80%
 
+# Structural connectivity module configuration
+connectivity:
+  iqr_multiplier: 1.5
+
 # Order that modules should appear in the report
 module_order:
   - framewise_displacement
@@ -82,3 +86,7 @@ sp:
     fn: "AgeCurve*.json"
   harmonization/harmonization_distance:
     fn: "*.bhattacharrya.txt"
+  connectivity/matrices:
+    fn: "*stat-*.npy"
+  connectivity/lut:
+    fn: "*LUT.json"

--- a/neuroimaging/custom_code.py
+++ b/neuroimaging/custom_code.py
@@ -107,3 +107,15 @@ def neuroimaging_execution_start():
             config.sp,
             {"harmonization/harmonization_distance": {"fn": "*.bhattacharrya.txt"}},
         )
+
+    if "connectivity/matrices" not in config.sp:
+        config.update_dict(
+            config.sp,
+            {"connectivity/matrices": {"fn": "*stat-*.npy"}},
+        )
+
+    if "connectivity/lut" not in config.sp:
+        config.update_dict(
+            config.sp,
+            {"connectivity/lut": {"fn": "*LUT.json"}},
+        )

--- a/neuroimaging/modules/connectivity/__init__.py
+++ b/neuroimaging/modules/connectivity/__init__.py
@@ -1,0 +1,3 @@
+from .connectivity import MultiqcModule  # noqa: F401
+
+__all__ = ["MultiqcModule"]

--- a/neuroimaging/modules/connectivity/connectivity.py
+++ b/neuroimaging/modules/connectivity/connectivity.py
@@ -73,20 +73,26 @@ class MultiqcModule(BaseMultiqcModule):
             info=module_info,
         )
 
-        # Find and parse connectivity matrix files
-        metrics_filter = getattr(config, "connectivity", {}).get("metrics", ["fa", "md", "rd", "commit"])
+        # Find and parse connectivity matrix files.
+        # If no metrics are configured, include every metric detected in input filenames.
+        module_config = getattr(config, "connectivity", {}) or {}
+        metrics_filter = self._parse_metrics_filter(module_config.get("metrics", None))
         conn_data = {}
         for f in self.find_log_files("connectivity/matrices"):
-            if any(metric in f["fn"] for metric in metrics_filter):
-                # Extract the metric that matched
-                metric = next(metric for metric in metrics_filter if metric in f["fn"])
-                parsed = self.parse_connectivity_file(f)
-                if parsed:
-                    sample_name = parsed["sample_name"]
-                    # Support multiple metrics per sample
-                    if sample_name not in conn_data:
-                        conn_data[sample_name] = {}
-                    conn_data[sample_name][metric] = parsed["values"]
+            metric = self._extract_metric_from_filename(f["fn"])
+            if metric is None:
+                log.debug(f"Could not infer connectivity metric from filename '{f['fn']}'. Skipping file.")
+                continue
+            if metrics_filter is not None and metric not in metrics_filter:
+                continue
+
+            parsed = self.parse_connectivity_file(f)
+            if parsed:
+                sample_name = parsed["sample_name"]
+                # Support multiple metrics per sample
+                if sample_name not in conn_data:
+                    conn_data[sample_name] = {}
+                conn_data[sample_name][metric] = parsed["values"]
 
         # Find LUT files.
         for f in self.find_log_files("connectivity/lut"):
@@ -207,6 +213,24 @@ class MultiqcModule(BaseMultiqcModule):
             "ycats_samples": False,
             "colstops": VIRIDIS_COLSTOPS,
         }
+
+    def _parse_metrics_filter(self, metrics_config):
+        """Normalize metrics configuration.
+
+        Returns None when all detected metrics should be included.
+        """
+        if metrics_config in (None, [], "all"):
+            return None
+        if isinstance(metrics_config, str):
+            return {metrics_config.lower()}
+        return {metric.lower() for metric in metrics_config}
+
+    def _extract_metric_from_filename(self, filename: str):
+        """Extract metric token from connectivity matrix filenames."""
+        match = re.search(r"stat-(.+?)\.npy$", filename, flags=re.IGNORECASE)
+        if not match:
+            return None
+        return match.group(1).lower()
 
     def _build_metric_selector(self, metrics: list, default_metric: str, sample_name: str) -> str:
         """Build dropdown HTML for selecting which metric heatmap is visible."""

--- a/neuroimaging/modules/connectivity/connectivity.py
+++ b/neuroimaging/modules/connectivity/connectivity.py
@@ -1,0 +1,132 @@
+"""
+===========================================
+Connectivity Module
+===========================================
+
+This module collects and visualizes connectivity matrices
+fromm connectome analysis. It supports the following file types:
+    * NumPy (.npy) connectivity matrices (for now)
+
+For global reports, it computes the density of the connectivity
+matrice, and plots the distribution across subjects in a violin plot.
+It also generates a heatmap of the average connectivity matrix
+across all subjects.
+
+For subject reports, it visualizes the individual connectivity
+matrix as a heatmap.
+"""
+
+import logging
+import re
+from typing import Dict
+
+import numpy as np
+
+from multiqc import config
+from multiqc.base_module import BaseMultiqcModule, ModuleNoSamplesFound
+from multiqc.plots import heatmap, violin
+
+log = logging.getLogger(__name__)
+
+
+class MultiqcModule(BaseMultiqcModule):
+    """ "MultiQC module for connectivity matrices."""
+
+    def __init__(self):
+        super(MultiqcModule, self).__init__(
+            name="Structural Connectivity",
+            anchor="connectivity",
+            href="https://github.com/nf-neuro/MultiQC_neuroimaging",
+            info="Assessment of structural connectivity for quality control."
+            " For each subject, the density of the connectivity matrix is computed,"
+            " and subjects with unusually low density are flagged. Additionally,"
+            " the average connectivity matrix across all subjects is visualized.",
+        )
+
+        #  Get the single-subject mode if set.
+        single_subject_mode = config.get("single_subject", False)
+
+        # Find and parse connectivity matrix files
+        conn_data = {}
+        config_fp = config.sp.get("connectivity", {}).get("fn", "")
+        for f in self.find_log_files("connectivity"):
+            parsed = self.parse_connectivity_file(f, config_fp)
+            if parsed:
+                sample_name = parsed["sample_name"]
+                conn_data[sample_name] = parsed["values"]
+
+        # Superfluous function call to confirm that it is used in this module
+        # Replace None with actual version if it is available
+        self.add_software_version(None)
+
+        # Filter by sample names.
+        conn_data = self.filter_samples(conn_data)
+
+        if len(conn_data) == 0:
+            raise ModuleNoSamplesFound
+
+        log.info(f"Found {len(conn_data)} samples.")
+
+        # Generate global plots if not in single-subject mode
+        if not single_subject_mode:
+            # Compute densities
+            densities = {s_name: {"density": self.compute_density(matrix)} for s_name, matrix in conn_data.items()}
+
+            # Add to general stats table.
+            self.general_stats_addcols(
+                densities,
+                {
+                    "density": {
+                        "title": "Structural Connectivity Density",
+                        "description": "Density of the connectivity matrix (proportion of non-zero connections).",
+                        "min": min(d["density"] for d in densities.values()),
+                        "max": max(d["density"] for d in densities.values()),
+                        "format": "{:.2f}",
+                    }
+                },
+            )
+
+    def parse_connectivity_file(self, f: str, config_fp: str) -> Dict:
+        """Parse a connectivity matrix file.
+
+        Args:
+            f (str): Path to the connectivity matrix file.
+            config_fp (str): Configured file path pattern to identify connectivity files.
+
+        Returns:
+            Dict: Parsed data including sample name and connectivity values.
+        """
+
+        values = np.load(f)
+
+        # Extract and clean sample name from filename.
+        # Using the pattern from custom_code.py for consistency.
+        # Remove the pattern suffix from filename to get the sample name.
+        filename = f["fn"]
+        pattern_suffix = config_fp.lstrip("*")
+        if pattern_suffix and filename.endswith(pattern_suffix):
+            # Similar to other modules, remove the suffix and any trailing underscores or hyphens.
+            sample_name = re.sub(r"_+$|-+$", "", filename[: -len(pattern_suffix)])
+        else:
+            # Fallback to the default way of cleaning sample names.
+            sample_name = f["s_name"]
+
+        # Apply MultiQC's sample name cleaning
+        sample_name = self.clean_s_name(sample_name, f)
+
+        return {"sample_name": sample_name, "values": values}
+
+    def compute_density(self, matrix: np.ndarray) -> float:
+        """Compute the density of a connectivity matrix.
+
+        Args:
+            matrix (np.ndarray): Connectivity matrix.
+
+        Returns:
+            float: Density of the connectivity matrix.
+        """
+        # Count non-zero connections
+        non_zero_connections = np.count_nonzero(matrix)
+        total_connections = matrix.size
+        density = non_zero_connections / total_connections
+        return density

--- a/neuroimaging/modules/connectivity/connectivity.py
+++ b/neuroimaging/modules/connectivity/connectivity.py
@@ -30,6 +30,15 @@ from multiqc.plots import heatmap
 log = logging.getLogger(__name__)
 
 
+VIRIDIS_COLSTOPS = [
+    [0.0, "#440154"],
+    [0.25, "#3b528b"],
+    [0.5, "#21918c"],
+    [0.75, "#5ec962"],
+    [1.0, "#fde725"],
+]
+
+
 class MultiqcModule(BaseMultiqcModule):
     """ "MultiQC module for connectivity matrices."""
 
@@ -158,76 +167,126 @@ class MultiqcModule(BaseMultiqcModule):
                         "display_values": False,
                         "xcats_samples": False,
                         "ycats_samples": False,
-                        # Mimick a viridis colormap.
-                        "colstops": [
-                            [0.0, "#440154"],
-                            [0.25, "#3b528b"],
-                            [0.5, "#21918c"],
-                            [0.75, "#5ec962"],
-                            [1.0, "#fde725"],
-                        ],
+                        # Mimic a viridis colormap.
+                        "colstops": VIRIDIS_COLSTOPS,
                     },
                 ),
                 statuses=status_groups,
             )
         else:
-            # In single-subject mode, just add the individual connectivity matrix as a heatmap.
-            # We assume select the first subject in the dictionary since there should only be one.
+            # In single-subject mode, render one matrix section controlled by a metric selector.
+            # We select the first sample because single-subject mode should only contain one sample.
             sample_name, metrics_dict = next(iter(conn_data.items()))
-            if len(metrics_dict) > 1:
-                # Multiple metrics available for this sample
-                for metric, matrix in metrics_dict.items():
-                    self.add_section(
-                        name=f"{metric.upper()} Connectivity Matrix",
-                        description=f"Individual structural connectivity matrix for {sample_name} weighted by the <strong>{metric.upper()}</strong> metric. "
-                        f"Each cell (i, j) represents the diffusion metric between regions i and j. "
-                        f"Values are displayed using a viridis colormap (purple=low, yellow=high). ",
-                        plot=heatmap.plot(
-                            matrix,
-                            xcats=[lut.get(str(i + 1)) for i in range(matrix.shape[0])],
-                            pconfig={
-                                "id": f"{sample_name}_{metric}_connectivity_matrix",
-                                "title": f"{metric.upper()} Connectivity Matrix",
-                                "display_values": False,
-                                "xcats_samples": False,
-                                "ycats_samples": False,
-                                "colstops": [
-                                    [0.0, "#440154"],
-                                    [0.25, "#3b528b"],
-                                    [0.5, "#21918c"],
-                                    [0.75, "#5ec962"],
-                                    [1.0, "#fde725"],
-                                ],
-                            },
-                        ),
-                    )
-            else:
-                # Only one metric available
-                metric, matrix = next(iter(metrics_dict.items()))
+            metrics = sorted(metrics_dict)
+            default_metric = metrics[0]
+
+            if len(metrics) > 1:
                 self.add_section(
-                    name="Connectivity Matrix",
-                    description=f"Individual structural connectivity matrix for {sample_name} weighted by the <strong>{metric.upper()}</strong> metric. "
-                    f"Each cell (i, j) represents the diffusion metric between brain regions i and j. "
-                    f"Values are displayed using a viridis colormap where purple indicates low/no connectivity and yellow indicates high connectivity. ",
-                    plot=heatmap.plot(
-                        matrix,
-                        xcats=[lut.get(str(i + 1)) for i in range(matrix.shape[0])],
-                        pconfig={
-                            "id": f"{sample_name}_connectivity_matrix",
-                            "title": "Connectivity Matrix",
-                            "display_values": False,
-                            "xcats_samples": False,
-                            "ycats_samples": False,
-                            "colstops": [
-                                [0.0, "#440154"],
-                                [0.25, "#3b528b"],
-                                [0.5, "#21918c"],
-                                [0.75, "#5ec962"],
-                                [1.0, "#fde725"],
-                            ],
-                        },
-                    ),
+                    name="Connectivity Metric Selection",
+                    anchor="connectivity_metric_selection",
+                    description="Select the diffusion metric used to display the connectivity matrix.",
+                    content=self._build_metric_selector(metrics, default_metric, sample_name),
                 )
+
+            self.add_section(
+                name="Connectivity Matrix",
+                anchor="connectivity_matrix",
+                description=f"Individual structural connectivity matrix for {sample_name}. "
+                "Each cell (i, j) represents the diffusion metric between brain regions i and j. "
+                "Values are displayed using a viridis colormap where purple indicates low/no connectivity and yellow indicates high connectivity.",
+                content=self._build_metric_matrices(metrics_dict, lut, sample_name, default_metric),
+            )
+
+    def _heatmap_pconfig(self, plot_id: str, title: str) -> Dict[str, object]:
+        """Return common heatmap configuration for connectivity plots."""
+        return {
+            "id": plot_id,
+            "title": title,
+            "display_values": False,
+            "xcats_samples": False,
+            "ycats_samples": False,
+            "colstops": VIRIDIS_COLSTOPS,
+        }
+
+    def _build_metric_selector(self, metrics: list, default_metric: str, sample_name: str) -> str:
+        """Build dropdown HTML for selecting which metric heatmap is visible."""
+        options_html = "".join(
+            [
+                f'<option value="{metric}" {"selected" if metric == default_metric else ""}>{metric.upper()}</option>'
+                for metric in metrics
+            ]
+        )
+        hook_name = f"renderConnectivityMetric_{re.sub(r'[^0-9a-zA-Z_]', '_', sample_name)}"
+        return f"""
+        <div class="d-flex justify-content-center">
+            <div class="text-center">
+                <label class="form-label mb-2 fw-semibold">Metric</label>
+                <select
+                    class="form-select shadow-sm"
+                    aria-label="Connectivity metric selection"
+                    onchange="if (typeof {hook_name} === 'function') {hook_name}(this.value)"
+                    style="min-width: 180px;"
+                >
+                    {options_html}
+                </select>
+            </div>
+        </div>
+        """
+
+    def _build_metric_matrices(
+        self,
+        metrics_dict: Dict[str, np.ndarray],
+        lut: Dict[str, str],
+        sample_name: str,
+        default_metric: str,
+    ) -> str:
+        """Build a single section containing all metric heatmaps and JS to toggle them."""
+        sample_id = re.sub(r"[^0-9a-zA-Z_]", "_", sample_name)
+        metric_plot_ids = {metric: f"{sample_name}_{metric}_connectivity_matrix" for metric in sorted(metrics_dict)}
+        content = ""
+        for metric, plot_id in metric_plot_ids.items():
+            matrix = metrics_dict[metric]
+            display = "block" if metric == default_metric else "none"
+            plot = heatmap.plot(
+                matrix,
+                xcats=[lut.get(str(i + 1)) for i in range(matrix.shape[0])],
+                pconfig=self._heatmap_pconfig(plot_id=plot_id, title=f"{metric.upper()} Connectivity Matrix"),
+            )
+            content += f"""
+            <div id="{plot_id}_container" style="display: {display};">
+                {plot.interactive_plot(self.anchor, "connectivity_matrix")}
+            </div>
+            """
+
+        hook_name = f"renderConnectivityMetric_{sample_id}"
+        containers_var = f"connectivity_metric_containers_{sample_id}"
+        content += f"""
+        <script>
+        var {containers_var} = {json.dumps(metric_plot_ids)};
+        function {hook_name}(metric) {{
+            Object.values({containers_var}).forEach(function(plotId) {{
+                document.getElementById(plotId + '_container').style.display = 'none';
+            }});
+
+            var selectedPlotId = {containers_var}[metric];
+            var selectedContainer = document.getElementById(selectedPlotId + '_container');
+            selectedContainer.style.display = 'block';
+
+            if (typeof renderPlot === 'function') {{
+                renderPlot(selectedPlotId);
+            }}
+
+            setTimeout(function() {{
+                var heatmapContainer = selectedContainer.querySelector('.mqc-heatmap-container');
+                if (heatmapContainer) {{
+                    heatmapContainer.dispatchEvent(new Event('resize'));
+                }}
+            }}, 0);
+        }}
+        </script>
+        """
+
+        return content
 
     def parse_connectivity_file(self, f: str) -> Dict:
         """Parse a connectivity matrix file.

--- a/neuroimaging/modules/connectivity/connectivity.py
+++ b/neuroimaging/modules/connectivity/connectivity.py
@@ -16,6 +16,7 @@ For subject reports, it visualizes the individual connectivity
 matrix as a heatmap.
 """
 
+import json
 import logging
 import re
 from typing import Dict
@@ -24,7 +25,7 @@ import numpy as np
 
 from multiqc import config
 from multiqc.base_module import BaseMultiqcModule, ModuleNoSamplesFound
-from multiqc.plots import heatmap, violin
+from multiqc.plots import heatmap
 
 log = logging.getLogger(__name__)
 
@@ -33,60 +34,202 @@ class MultiqcModule(BaseMultiqcModule):
     """ "MultiQC module for connectivity matrices."""
 
     def __init__(self):
+        #  Get the single-subject mode if set.
+        single_subject_mode = config.kwargs.get("single_subject", False)
+
+        # Tailor the module description based on the mode
+        if single_subject_mode:
+            module_info = (
+                "Visualization of individual structural connectivity matrices for detailed quality inspection. "
+                "Each connectivity matrix is displayed as a heatmap showing diffusion metric between brain regions. "
+                "Assess the matrix for bilateral symmetry, anatomical plausibility, isolated regions, and unexpected artifacts. "
+                "The density (proportion of non-zero connections) provides a summary metric for overall connectivity. "
+                "If multiple diffusion metrics (FA, MD, RD, AD) are available, separate heatmaps are generated for comparison."
+            )
+        else:
+            module_info = (
+                "Comprehensive cohort-level assessment of structural connectivity matrices for quality control. "
+                "For each subject, the density of the connectivity matrix (proportion of non-zero connections) is computed "
+                "to identify subjects with unusually sparse or dense connectomes that may indicate processing issues. "
+                "Subjects are automatically flagged based on statistical outlier detection (IQR method: fail beyond 1.5×IQR, warn beyond Q1/Q3). "
+                "The frequency matrix visualizes connection consistency across all subjects, helping identify "
+                "systematic connectivity patterns and potential anatomical or processing artifacts. "
+                "High-frequency connections indicate consistent structural pathways, while extremely low frequencies may suggest tractography or thresholding issues."
+            )
+
         super(MultiqcModule, self).__init__(
             name="Structural Connectivity",
             anchor="connectivity",
             href="https://github.com/nf-neuro/MultiQC_neuroimaging",
-            info="Assessment of structural connectivity for quality control."
-            " For each subject, the density of the connectivity matrix is computed,"
-            " and subjects with unusually low density are flagged. Additionally,"
-            " the average connectivity matrix across all subjects is visualized.",
+            info=module_info,
         )
 
-        #  Get the single-subject mode if set.
-        single_subject_mode = config.get("single_subject", False)
-
         # Find and parse connectivity matrix files
+        metrics_filter = getattr(config, "connectivity", {}).get("metrics", ["fa", "md", "rd", "commit"])
         conn_data = {}
-        config_fp = config.sp.get("connectivity", {}).get("fn", "")
-        for f in self.find_log_files("connectivity"):
-            parsed = self.parse_connectivity_file(f, config_fp)
-            if parsed:
-                sample_name = parsed["sample_name"]
-                conn_data[sample_name] = parsed["values"]
+        for f in self.find_log_files("connectivity/matrices"):
+            if any(metric in f["fn"] for metric in metrics_filter):
+                # Extract the metric that matched
+                metric = next(metric for metric in metrics_filter if metric in f["fn"])
+                parsed = self.parse_connectivity_file(f)
+                if parsed:
+                    sample_name = parsed["sample_name"]
+                    # Support multiple metrics per sample
+                    if sample_name not in conn_data:
+                        conn_data[sample_name] = {}
+                    conn_data[sample_name][metric] = parsed["values"]
+
+        # Find LUT files.
+        for f in self.find_log_files("connectivity/lut"):
+            # Just need to load a single JSON file to get the LUT,
+            # so we can break after the first one.
+            with open(f["root"] + "/" + f["fn"], "r") as fp:
+                lut = json.load(fp)
+            break
 
         # Superfluous function call to confirm that it is used in this module
         # Replace None with actual version if it is available
         self.add_software_version(None)
 
         # Filter by sample names.
-        conn_data = self.filter_samples(conn_data)
+        conn_data = self.ignore_samples(conn_data)
 
         if len(conn_data) == 0:
             raise ModuleNoSamplesFound
 
-        log.info(f"Found {len(conn_data)} samples.")
+        log.info(f"Found {len(conn_data)} samples")
 
         # Generate global plots if not in single-subject mode
         if not single_subject_mode:
-            # Compute densities
-            densities = {s_name: {"density": self.compute_density(matrix)} for s_name, matrix in conn_data.items()}
+            # Compute densities - use the first available metric for each sample
+            densities = {
+                s_name: {"density": self.compute_density(next(iter(metrics.values())))}
+                for s_name, metrics in conn_data.items()
+            }
+
+            # Identify outliers based on density (e.g. using X * IQR rule)
+            config_thresh = getattr(config, "connectivity", {})
+            iqr_multiplier = config_thresh.get("iqr_multiplier", 1.5)
+            density_values = [d["density"] for d in densities.values()]
+            q1, q3 = np.percentile(density_values, [25, 75])
+            iqr = q3 - q1
+
+            lower_bound = q1 - iqr_multiplier * iqr
+            upper_bound = q3 + iqr_multiplier * iqr
+
+            for s_name, d in densities.items():
+                if d["density"] < lower_bound or d["density"] > upper_bound:
+                    d["flag"] = "fail"
+                elif d["density"] < q1 or d["density"] > q3:
+                    d["flag"] = "warn"
+                else:
+                    d["flag"] = "pass"
+
+            status_groups = {"pass": [], "warn": [], "fail": []}
+            for s_name, d in densities.items():
+                status_groups[d["flag"]].append(s_name)
 
             # Add to general stats table.
             self.general_stats_addcols(
                 densities,
                 {
                     "density": {
-                        "title": "Structural Connectivity Density",
+                        "title": "Density",
                         "description": "Density of the connectivity matrix (proportion of non-zero connections).",
-                        "min": min(d["density"] for d in densities.values()),
-                        "max": max(d["density"] for d in densities.values()),
+                        "min": min(d["density"] for d in densities.values()) - 0.1,
+                        "max": max(d["density"] for d in densities.values()) + 0.1,
                         "format": "{:.2f}",
                     }
                 },
             )
+            # Generate the frequency matrix and plot it as a heatmap.
+            freq_mat = self.frequency_matrix(conn_data, tuple((len(lut), len(lut))))
+            self.add_section(
+                name="Connectivity Frequency Matrix",
+                description="This heatmap displays the frequency of connections across all subjects in the cohort. "
+                "Each cell (i, j) represents the proportion of subjects that have a non-zero connection between regions i and j. "
+                "Values range from 0 (purple, connection never present) to 1 (yellow, connection present in all subjects). ",
+                plot=heatmap.plot(
+                    freq_mat,
+                    xcats=[lut.get(str(i + 1)) for i in range(freq_mat.shape[0])],
+                    pconfig={
+                        "id": "connectivity_frequency_matrix",
+                        "title": "Connectivity Frequency Matrix",
+                        "display_values": False,
+                        "xcats_samples": False,
+                        "ycats_samples": False,
+                        # Mimick a viridis colormap.
+                        "colstops": [
+                            [0.0, "#440154"],
+                            [0.25, "#3b528b"],
+                            [0.5, "#21918c"],
+                            [0.75, "#5ec962"],
+                            [1.0, "#fde725"],
+                        ],
+                    },
+                ),
+                statuses=status_groups,
+            )
+        else:
+            # In single-subject mode, just add the individual connectivity matrix as a heatmap.
+            # We assume select the first subject in the dictionary since there should only be one.
+            sample_name, metrics_dict = next(iter(conn_data.items()))
+            if len(metrics_dict) > 1:
+                # Multiple metrics available for this sample
+                for metric, matrix in metrics_dict.items():
+                    self.add_section(
+                        name=f"{metric.upper()} Connectivity Matrix",
+                        description=f"Individual structural connectivity matrix for {sample_name} weighted by the <strong>{metric.upper()}</strong> metric. "
+                        f"Each cell (i, j) represents the diffusion metric between regions i and j. "
+                        f"Values are displayed using a viridis colormap (purple=low, yellow=high). ",
+                        plot=heatmap.plot(
+                            matrix,
+                            xcats=[lut.get(str(i + 1)) for i in range(matrix.shape[0])],
+                            pconfig={
+                                "id": f"{sample_name}_{metric}_connectivity_matrix",
+                                "title": f"{metric.upper()} Connectivity Matrix",
+                                "display_values": False,
+                                "xcats_samples": False,
+                                "ycats_samples": False,
+                                "colstops": [
+                                    [0.0, "#440154"],
+                                    [0.25, "#3b528b"],
+                                    [0.5, "#21918c"],
+                                    [0.75, "#5ec962"],
+                                    [1.0, "#fde725"],
+                                ],
+                            },
+                        ),
+                    )
+            else:
+                # Only one metric available
+                metric, matrix = next(iter(metrics_dict.items()))
+                self.add_section(
+                    name="Connectivity Matrix",
+                    description=f"Individual structural connectivity matrix for {sample_name} weighted by the <strong>{metric.upper()}</strong> metric. "
+                    f"Each cell (i, j) represents the diffusion metric between brain regions i and j. "
+                    f"Values are displayed using a viridis colormap where purple indicates low/no connectivity and yellow indicates high connectivity. ",
+                    plot=heatmap.plot(
+                        matrix,
+                        xcats=[lut.get(str(i + 1)) for i in range(matrix.shape[0])],
+                        pconfig={
+                            "id": f"{sample_name}_connectivity_matrix",
+                            "title": "Connectivity Matrix",
+                            "display_values": False,
+                            "xcats_samples": False,
+                            "ycats_samples": False,
+                            "colstops": [
+                                [0.0, "#440154"],
+                                [0.25, "#3b528b"],
+                                [0.5, "#21918c"],
+                                [0.75, "#5ec962"],
+                                [1.0, "#fde725"],
+                            ],
+                        },
+                    ),
+                )
 
-    def parse_connectivity_file(self, f: str, config_fp: str) -> Dict:
+    def parse_connectivity_file(self, f: str) -> Dict:
         """Parse a connectivity matrix file.
 
         Args:
@@ -96,20 +239,20 @@ class MultiqcModule(BaseMultiqcModule):
         Returns:
             Dict: Parsed data including sample name and connectivity values.
         """
-
-        values = np.load(f)
+        values = np.load(f["root"] + "/" + f["fn"])
 
         # Extract and clean sample name from filename.
-        # Using the pattern from custom_code.py for consistency.
-        # Remove the pattern suffix from filename to get the sample name.
-        filename = f["fn"]
-        pattern_suffix = config_fp.lstrip("*")
-        if pattern_suffix and filename.endswith(pattern_suffix):
-            # Similar to other modules, remove the suffix and any trailing underscores or hyphens.
-            sample_name = re.sub(r"_+$|-+$", "", filename[: -len(pattern_suffix)])
-        else:
-            # Fallback to the default way of cleaning sample names.
+        # Since patterns can vary between atlases and stats, we should manually match
+        # patterns with sub-XXXXX, ses-XXXX, and run-ZZZ assuming BIDS structure.
+        match = re.search(r"sub-[a-zA-Z0-9]+(_ses-[a-zA-Z0-9]+)?(_run-[a-zA-Z0-9]+)?", f["fn"])
+        if match:
+            sample_name = match.group(0)
+        elif "s_name" in f:
+            # If the sample name is already provided in the file metadata, use it.
             sample_name = f["s_name"]
+        elif "fn" in f:
+            # As a last resort, use the filename as the sample name.
+            sample_name = f["fn"]
 
         # Apply MultiQC's sample name cleaning
         sample_name = self.clean_s_name(sample_name, f)
@@ -123,10 +266,39 @@ class MultiqcModule(BaseMultiqcModule):
             matrix (np.ndarray): Connectivity matrix.
 
         Returns:
-            float: Density of the connectivity matrix.
+            float: Density of the connectivity matrix (proportion between 0 and 1).
         """
         # Count non-zero connections
         non_zero_connections = np.count_nonzero(matrix)
         total_connections = matrix.size
-        density = non_zero_connections / total_connections
+        # Compute density and rescale to be between 0 and 1
+        density = non_zero_connections / total_connections if total_connections > 0 else 0
+
         return density
+
+    def frequency_matrix(self, matrices: Dict[str, Dict[str, np.ndarray]], shape: tuple = None) -> np.ndarray:
+        """Compute the frequency of all connections across subjects.
+
+        Args:
+            matrices (Dict[str, Dict[str, np.ndarray]]): Dictionary of sample names and their metrics dictionaries.
+            shape (tuple): Expected shape of the connectivity matrices.
+
+        Returns:
+            np.ndarray: Frequency matrix where each element represents the proportion of subjects
+                        with this connection present.
+        """
+        # Create empty zero matrix to store results.
+        # Get the first matrix from the first sample's first metric
+        first_matrix = next(iter(next(iter(matrices.values())).values()))
+        freq_mat = np.zeros(shape if shape else first_matrix.shape)
+
+        for sub, metrics_dict in matrices.items():
+            # Use the first available metric for each subject
+            matrix = next(iter(metrics_dict.values()))
+            # Small check to ensure matrices are the expected shape.
+            if matrix.shape != freq_mat.shape:
+                log.warning(f"Matrix for subject {sub} has shape {matrix.shape}, expected {freq_mat.shape}. Skipping.")
+                continue
+            freq_mat += np.where(matrix != 0, 1, 0)  # Increment by 1 where connection is present
+
+        return freq_mat / len(matrices)  # Rescale to be between 0 and 1

--- a/neuroimaging/modules/connectivity/tests/__init__.py
+++ b/neuroimaging/modules/connectivity/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the connectivity module."""

--- a/neuroimaging/modules/connectivity/tests/test_connectivity.py
+++ b/neuroimaging/modules/connectivity/tests/test_connectivity.py
@@ -150,6 +150,17 @@ def test_compute_density(reset_multiqc):
     assert module.compute_density(matrix) == pytest.approx(0.75)
 
 
+def test_extract_metric_from_filename_captures_until_npy(reset_multiqc):
+    """Test that metric extraction captures everything between stat- and .npy."""
+    from neuroimaging.modules.connectivity import connectivity
+
+    module = object.__new__(connectivity.MultiqcModule)
+
+    metric = module._extract_metric_from_filename("sub-01_connectome_stat-commit-v2.extra.npy")
+
+    assert metric == "commit-v2.extra"
+
+
 def test_frequency_matrix(reset_multiqc):
     """Test frequency matrix calculation across subjects."""
     from neuroimaging.modules.connectivity import connectivity
@@ -276,6 +287,66 @@ def test_single_subject_mode_adds_metric_selector_and_single_matrix_section(rese
         assert "sub-SINGLE_fa_connectivity_matrix_container" in matrix_section.content
         assert "sub-SINGLE_md_connectivity_matrix_container" in matrix_section.content
         assert "renderConnectivityMetric_sub_SINGLE" in matrix_section.content
+    finally:
+        shutil.rmtree(tmpdir)
+
+
+def test_single_subject_mode_fetches_all_metrics_when_metrics_config_is_empty(reset_multiqc):
+    """Test that an empty metrics config includes all detected metrics."""
+    from neuroimaging.modules.connectivity import connectivity
+
+    tmpdir = tempfile.mkdtemp()
+
+    try:
+        _write_lut(os.path.join(tmpdir, "atlas_LUT.json"), size=3)
+        np.save(os.path.join(tmpdir, "sub-SINGLE_stat-fa.npy"), _binary_matrix(3, shape=(3, 3)))
+        np.save(os.path.join(tmpdir, "sub-SINGLE_stat-md.npy"), _binary_matrix(5, shape=(3, 3)))
+
+        config.kwargs = {"single_subject": True}
+        config.connectivity = {"metrics": []}
+        _register_connectivity_files(
+            tmpdir,
+            ["sub-SINGLE_stat-fa.npy", "sub-SINGLE_stat-md.npy"],
+        )
+
+        module = connectivity.MultiqcModule()
+        selector_section, matrix_section = module.sections
+
+        assert len(module.sections) == 2
+        assert selector_section.name == "Connectivity Metric Selection"
+        assert "FA" in selector_section.content
+        assert "MD" in selector_section.content
+        assert "sub-SINGLE_fa_connectivity_matrix_container" in matrix_section.content
+        assert "sub-SINGLE_md_connectivity_matrix_container" in matrix_section.content
+    finally:
+        shutil.rmtree(tmpdir)
+
+
+def test_single_subject_mode_metrics_filter_keeps_only_selected_metric(reset_multiqc):
+    """Test that configured metrics filter restricts displayed matrices."""
+    from neuroimaging.modules.connectivity import connectivity
+
+    tmpdir = tempfile.mkdtemp()
+
+    try:
+        _write_lut(os.path.join(tmpdir, "atlas_LUT.json"), size=3)
+        np.save(os.path.join(tmpdir, "sub-SINGLE_stat-fa.npy"), _binary_matrix(3, shape=(3, 3)))
+        np.save(os.path.join(tmpdir, "sub-SINGLE_stat-md.npy"), _binary_matrix(5, shape=(3, 3)))
+
+        config.kwargs = {"single_subject": True}
+        config.connectivity = {"metrics": ["md"]}
+        _register_connectivity_files(
+            tmpdir,
+            ["sub-SINGLE_stat-fa.npy", "sub-SINGLE_stat-md.npy"],
+        )
+
+        module = connectivity.MultiqcModule()
+
+        assert len(module.sections) == 1
+        matrix_section = module.sections[0]
+        assert matrix_section.name == "Connectivity Matrix"
+        assert "sub-SINGLE_md_connectivity_matrix_container" in matrix_section.content
+        assert "sub-SINGLE_fa_connectivity_matrix_container" not in matrix_section.content
     finally:
         shutil.rmtree(tmpdir)
 

--- a/neuroimaging/modules/connectivity/tests/test_connectivity.py
+++ b/neuroimaging/modules/connectivity/tests/test_connectivity.py
@@ -245,8 +245,8 @@ def test_ignore_samples_filters_general_stats(reset_multiqc, test_data_dir):
     config.sample_names_ignore = []
 
 
-def test_single_subject_mode_adds_one_section_per_metric(reset_multiqc):
-    """Test that single-subject mode renders one heatmap per available metric."""
+def test_single_subject_mode_adds_metric_selector_and_single_matrix_section(reset_multiqc):
+    """Test that single-subject mode uses one selector and one matrix section."""
     from neuroimaging.modules.connectivity import connectivity
 
     tmpdir = tempfile.mkdtemp()
@@ -264,9 +264,18 @@ def test_single_subject_mode_adds_one_section_per_metric(reset_multiqc):
 
         module = connectivity.MultiqcModule()
 
-        section_names = {section.name for section in module.sections}
         assert len(module.sections) == 2
-        assert section_names == {"FA Connectivity Matrix", "MD Connectivity Matrix"}
+
+        selector_section, matrix_section = module.sections
+        assert selector_section.name == "Connectivity Metric Selection"
+        assert "<select" in selector_section.content
+        assert "FA" in selector_section.content
+        assert "MD" in selector_section.content
+
+        assert matrix_section.name == "Connectivity Matrix"
+        assert "sub-SINGLE_fa_connectivity_matrix_container" in matrix_section.content
+        assert "sub-SINGLE_md_connectivity_matrix_container" in matrix_section.content
+        assert "renderConnectivityMetric_sub_SINGLE" in matrix_section.content
     finally:
         shutil.rmtree(tmpdir)
 

--- a/neuroimaging/modules/connectivity/tests/test_connectivity.py
+++ b/neuroimaging/modules/connectivity/tests/test_connectivity.py
@@ -1,0 +1,289 @@
+"""Tests for the connectivity module."""
+
+import json
+import os
+import shutil
+import tempfile
+
+import numpy as np
+import pytest
+from multiqc import config, report
+from multiqc.base_module import ModuleNoSamplesFound
+
+
+def _binary_matrix(non_zero_count, shape=(10, 10)):
+    """Create a matrix with a fixed number of non-zero entries."""
+    matrix = np.zeros(shape[0] * shape[1], dtype=float)
+    matrix[:non_zero_count] = 1.0
+    return matrix.reshape(shape)
+
+
+def _write_lut(path, size=10):
+    """Write a minimal LUT file for heatmap labels."""
+    with open(path, "w") as handle:
+        json.dump({str(index + 1): f"Region {index + 1}" for index in range(size)}, handle)
+
+
+def _register_connectivity_files(data_dir, matrix_files, lut_file="atlas_LUT.json"):
+    """Populate MultiQC report file metadata for connectivity inputs."""
+    config.analysis_dir = [data_dir]
+    report.files["connectivity/matrices"] = [
+        {
+            "fn": filename,
+            "root": data_dir,
+            "s_name": os.path.splitext(filename)[0],
+            "sp_key": "connectivity/matrices",
+        }
+        for filename in matrix_files
+    ]
+    report.files["connectivity/lut"] = [
+        {
+            "fn": lut_file,
+            "root": data_dir,
+            "s_name": os.path.splitext(lut_file)[0],
+            "sp_key": "connectivity/lut",
+        }
+    ]
+
+
+@pytest.fixture
+def reset_multiqc():
+    """Reset MultiQC state before each test."""
+    config.reset()
+    report.reset()
+    if "connectivity/matrices" not in config.sp:
+        config.update_dict(config.sp, {"connectivity/matrices": {"fn": "*stat-*.npy"}})
+    if "connectivity/lut" not in config.sp:
+        config.update_dict(config.sp, {"connectivity/lut": {"fn": "*LUT.json"}})
+    yield
+    config.reset()
+    report.reset()
+
+
+@pytest.fixture
+def test_data_dir():
+    """Create a temporary directory with connectivity matrices and a LUT."""
+    tmpdir = tempfile.mkdtemp()
+    density_cases = {
+        "sub-WARN_stat-fa.npy": 24,
+        "sub-PASS1_stat-fa.npy": 25,
+        "sub-PASS2_stat-fa.npy": 26,
+        "sub-PASS3_stat-fa.npy": 27,
+        "sub-FAIL_stat-fa.npy": 100,
+    }
+
+    _write_lut(os.path.join(tmpdir, "atlas_LUT.json"))
+    for filename, non_zero_count in density_cases.items():
+        np.save(os.path.join(tmpdir, filename), _binary_matrix(non_zero_count))
+
+    yield tmpdir
+
+    shutil.rmtree(tmpdir)
+
+
+def test_module_import():
+    """Test that the connectivity module can be imported."""
+    from neuroimaging.modules.connectivity import connectivity
+
+    assert hasattr(connectivity, "MultiqcModule")
+
+
+def test_parse_connectivity_file_extracts_bids_sample_name(reset_multiqc):
+    """Test parsing a connectivity file with a BIDS-style sample name."""
+    from neuroimaging.modules.connectivity import connectivity
+
+    tmpdir = tempfile.mkdtemp()
+    matrix = np.array([[0.0, 1.0], [1.0, 0.0]])
+    filename = "sub-P001_ses-BL_run-01_stat-fa.npy"
+
+    try:
+        np.save(os.path.join(tmpdir, filename), matrix)
+        module = object.__new__(connectivity.MultiqcModule)
+        parsed = module.parse_connectivity_file(
+            {
+                "fn": filename,
+                "root": tmpdir,
+                "s_name": "ignored",
+                "sp_key": "connectivity/matrices",
+            }
+        )
+
+        assert parsed["sample_name"] == "sub-P001_ses-BL_run-01"
+        np.testing.assert_array_equal(parsed["values"], matrix)
+    finally:
+        shutil.rmtree(tmpdir)
+
+
+def test_parse_connectivity_file_falls_back_to_s_name(reset_multiqc):
+    """Test parsing falls back to MultiQC metadata when no BIDS ID is present."""
+    from neuroimaging.modules.connectivity import connectivity
+
+    tmpdir = tempfile.mkdtemp()
+    matrix = np.array([[1.0, 0.0], [0.0, 1.0]])
+    filename = "atlas_stat-fa.npy"
+
+    try:
+        np.save(os.path.join(tmpdir, filename), matrix)
+        module = object.__new__(connectivity.MultiqcModule)
+        parsed = module.parse_connectivity_file(
+            {
+                "fn": filename,
+                "root": tmpdir,
+                "s_name": "subject_from_metadata",
+                "sp_key": "connectivity/matrices",
+            }
+        )
+
+        assert parsed["sample_name"] == "subject_from_metadata"
+        np.testing.assert_array_equal(parsed["values"], matrix)
+    finally:
+        shutil.rmtree(tmpdir)
+
+
+def test_compute_density(reset_multiqc):
+    """Test density calculation on a simple connectivity matrix."""
+    from neuroimaging.modules.connectivity import connectivity
+
+    module = object.__new__(connectivity.MultiqcModule)
+    matrix = np.array([[1.0, 0.0], [1.0, 1.0]])
+
+    assert module.compute_density(matrix) == pytest.approx(0.75)
+
+
+def test_frequency_matrix(reset_multiqc):
+    """Test frequency matrix calculation across subjects."""
+    from neuroimaging.modules.connectivity import connectivity
+
+    matrices = {
+        "sub-A": {"fa": np.array([[1.0, 0.0], [0.0, 1.0]])},
+        "sub-B": {"md": np.array([[0.0, 1.0], [1.0, 1.0]])},
+    }
+
+    module = object.__new__(connectivity.MultiqcModule)
+    frequency = module.frequency_matrix(matrices)
+
+    expected = np.array([[0.5, 0.5], [0.5, 1.0]])
+    np.testing.assert_array_equal(frequency, expected)
+
+
+def test_global_mode_adds_density_stats_and_statuses(reset_multiqc, test_data_dir):
+    """Test cohort mode density statistics and IQR-based status assignment."""
+    from neuroimaging.modules.connectivity import connectivity
+
+    config.kwargs = {"single_subject": False}
+    matrix_files = [
+        "sub-WARN_stat-fa.npy",
+        "sub-PASS1_stat-fa.npy",
+        "sub-PASS2_stat-fa.npy",
+        "sub-PASS3_stat-fa.npy",
+        "sub-FAIL_stat-fa.npy",
+    ]
+    _register_connectivity_files(test_data_dir, matrix_files)
+
+    module = connectivity.MultiqcModule()
+
+    assert module is not None
+    assert len(module.sections) == 1
+    assert module.sections[0].name == "Connectivity Frequency Matrix"
+
+    section = module.sections[0]
+    assert '"sub-WARN": "warn"' in section.status_bar_html
+    assert '"sub-PASS2": "pass"' in section.status_bar_html
+    assert '"sub-FAIL": "fail"' in section.status_bar_html
+
+    assert len(report.general_stats_data) > 0
+    general_stats = list(report.general_stats_data.values())[0]
+    assert general_stats["sub-WARN"][0].data["density"] == pytest.approx(0.24)
+    assert general_stats["sub-PASS2"][0].data["density"] == pytest.approx(0.26)
+    assert general_stats["sub-FAIL"][0].data["density"] == pytest.approx(1.0)
+
+
+def test_configurable_iqr_multiplier_changes_outlier_status(reset_multiqc, test_data_dir):
+    """Test that a custom IQR multiplier affects cohort status thresholds."""
+    from neuroimaging.modules.connectivity import connectivity
+
+    config.connectivity = {"iqr_multiplier": 100}
+    config.kwargs = {"single_subject": False}
+    matrix_files = [
+        "sub-WARN_stat-fa.npy",
+        "sub-PASS1_stat-fa.npy",
+        "sub-PASS2_stat-fa.npy",
+        "sub-PASS3_stat-fa.npy",
+        "sub-FAIL_stat-fa.npy",
+    ]
+    _register_connectivity_files(test_data_dir, matrix_files)
+
+    module = connectivity.MultiqcModule()
+    section = module.sections[0]
+
+    assert '"sub-FAIL": "warn"' in section.status_bar_html
+    assert '"sub-PASS2": "pass"' in section.status_bar_html
+
+
+def test_ignore_samples_filters_general_stats(reset_multiqc, test_data_dir):
+    """Test ignore_samples configuration."""
+    from neuroimaging.modules.connectivity import connectivity
+
+    config.kwargs = {"single_subject": False}
+    config.sample_names_ignore = ["sub-WARN"]
+    matrix_files = [
+        "sub-WARN_stat-fa.npy",
+        "sub-PASS1_stat-fa.npy",
+        "sub-PASS2_stat-fa.npy",
+        "sub-PASS3_stat-fa.npy",
+        "sub-FAIL_stat-fa.npy",
+    ]
+    _register_connectivity_files(test_data_dir, matrix_files)
+
+    connectivity.MultiqcModule()
+
+    general_stats = list(report.general_stats_data.values())[0]
+    assert "sub-WARN" not in general_stats
+    assert "sub-PASS1" in general_stats
+    assert len(general_stats) == 4
+
+    config.sample_names_ignore = []
+
+
+def test_single_subject_mode_adds_one_section_per_metric(reset_multiqc):
+    """Test that single-subject mode renders one heatmap per available metric."""
+    from neuroimaging.modules.connectivity import connectivity
+
+    tmpdir = tempfile.mkdtemp()
+
+    try:
+        _write_lut(os.path.join(tmpdir, "atlas_LUT.json"), size=3)
+        np.save(os.path.join(tmpdir, "sub-SINGLE_stat-fa.npy"), _binary_matrix(3, shape=(3, 3)))
+        np.save(os.path.join(tmpdir, "sub-SINGLE_stat-md.npy"), _binary_matrix(5, shape=(3, 3)))
+
+        config.kwargs = {"single_subject": True}
+        _register_connectivity_files(
+            tmpdir,
+            ["sub-SINGLE_stat-fa.npy", "sub-SINGLE_stat-md.npy"],
+        )
+
+        module = connectivity.MultiqcModule()
+
+        section_names = {section.name for section in module.sections}
+        assert len(module.sections) == 2
+        assert section_names == {"FA Connectivity Matrix", "MD Connectivity Matrix"}
+    finally:
+        shutil.rmtree(tmpdir)
+
+
+def test_empty_input_raises_module_no_samples_found(reset_multiqc):
+    """Test handling of missing connectivity matrix inputs."""
+    from neuroimaging.modules.connectivity import connectivity
+
+    tmpdir = tempfile.mkdtemp()
+
+    try:
+        config.analysis_dir = [tmpdir]
+        config.kwargs = {"single_subject": False}
+        report.files["connectivity/matrices"] = []
+        report.files["connectivity/lut"] = []
+
+        with pytest.raises(ModuleNoSamplesFound):
+            connectivity.MultiqcModule()
+    finally:
+        shutil.rmtree(tmpdir)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ packages = [
     "neuroimaging.modules.framewise_displacement",
     "neuroimaging.modules.coverage",
     "neuroimaging.modules.streamline_count",
+    "neuroimaging.modules.connectivity",
 ]
 
 [project.urls]
@@ -70,6 +71,7 @@ coverage = "neuroimaging.modules.coverage:MultiqcModule"
 streamline_count = "neuroimaging.modules.streamline_count:MultiqcModule"
 metricsinroi = "neuroimaging.modules.metricsinroi:MultiqcModule"
 harmonization = "neuroimaging.modules.harmonization.harmonization:MultiqcModule"
+connectivity = "neuroimaging.modules.connectivity:MultiqcModule"
 
 [project.entry-points."multiqc.cli_options.v1"]
 single_subject = "neuroimaging.cli:single_subject"

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -14,6 +14,7 @@ from multiqc import BaseMultiqcModule, config, report
 # List of all neuroimaging modules
 modules = [
     ("tractometry", "neuroimaging.modules.tractometry:MultiqcModule"),
+    ("connectivity", "neuroimaging.modules.connectivity:MultiqcModule"),
     ("cortical", "neuroimaging.modules.cortical:MultiqcModule"),
     ("subcortical", "neuroimaging.modules.subcortical:MultiqcModule"),
     (


### PR DESCRIPTION
New connectivity module. 

Behavior for global report:
* Compute the density of each subject, flag the subject outside 1.5IQR, and add the density to the general statistic table.
* Will also compute a frequency matrix and plot it as a heatmap in a section.

Example report: 
[multiqc_report.html](https://github.com/user-attachments/files/25948852/multiqc_report.html)


Behavior for single subject report:
* Simply plot FA, MD, and COMMIT weights (if available) as heatmaps.

Example report:
[multiqc_report.html](https://github.com/user-attachments/files/25948870/multiqc_report.html)
