### PR TITLE
FEAT: Add new module for viewing bundles in single subject report

### DIFF
--- a/multiqc_config.yaml
+++ b/multiqc_config.yaml
@@ -1,6 +1,10 @@
 ---
 # MultiQC example configuration for MultiQC_neuroimaging
 
+# Bundles module configuration default values.
+bundles:
+  bundles: [] # List of bundles to include, otherwise will use all detected bundles.
+
 # Streamline Count module configuration default thresholds
 streamline_count:
   iqr_multiplier: 3 # Default: samples outside Q1 - 3*IQR to Q3 + 3*IQR are marked as fail
@@ -66,6 +70,7 @@ module_order:
   - framewise_displacement
   - coverage
   - streamline_count
+  - bundles
   - tractometry
   - metricsinroi
   - harmonization
@@ -80,6 +85,10 @@ sp:
     fn: "*coverage_metrics.tsv"
   streamline_count:
     fn: "*streamline_count.tsv"
+  bundles/trk:
+    fn: "*.trk"
+  bundles/nii:
+    fn: "*.nii.gz"
   tractometry:
     fn: "*bundles_mean_stats.tsv"
     shared: true

--- a/neuroimaging/custom_code.py
+++ b/neuroimaging/custom_code.py
@@ -125,3 +125,15 @@ def neuroimaging_execution_start():
             config.sp,
             {"connectivity/lut": {"fn": "*LUT.json"}},
         )
+
+    if "bundles/trk" not in config.sp:
+        config.update_dict(
+            config.sp,
+            {"bundles/trk": {"fn": "*.trk"}},
+        )
+
+    if "bundles/nii" not in config.sp:
+        config.update_dict(
+            config.sp,
+            {"bundles/nii": {"fn": "*.nii.gz"}},
+        )

--- a/neuroimaging/modules/bundles/__init__.py
+++ b/neuroimaging/modules/bundles/__init__.py
@@ -1,0 +1,3 @@
+from .bundles import MultiqcModule
+
+__all__ = ["MultiqcModule"]

--- a/neuroimaging/modules/bundles/bundles.py
+++ b/neuroimaging/modules/bundles/bundles.py
@@ -23,13 +23,10 @@ import tempfile
 from contextlib import redirect_stdout
 from typing import Dict, List
 
-import nibabel as nib
 import numpy as np
 import pyvista as pv
 import yabplot as yab
-from scipy.ndimage import gaussian_filter
 from skimage import io as skio
-from skimage import measure
 
 from multiqc import config
 from multiqc.base_module import BaseMultiqcModule, ModuleNoSamplesFound
@@ -108,7 +105,7 @@ class MultiqcModule(BaseMultiqcModule):
                 raise ModuleNoSamplesFound("No valid .trk files found to parse bundle names.")
 
         log.info(f"Found {len(trk_dict)} bundles to visualize")
-        bg_mesh = self._load_nii_as_mesh(nii_file) if nii_file else None
+        bg_mesh = yab.load_nii_as_mesh(nii_file) if nii_file else None
 
         bundle_images = self._render_bundle_images(trk_dict, bg_mesh)
         if not bundle_images:
@@ -124,8 +121,7 @@ class MultiqcModule(BaseMultiqcModule):
                 "Use the dropdown to switch between bundle previews. The figure shows the bundle extraction "
                 "for one tract at a time so you can inspect anatomy and spurious streamlines more easily. "
                 "<b>Views include, from left to right, superior, right lateral, left lateral, and anterior.</b> "
-                "In the left and right views, the view not containing the specific bundle will be empty "
-                "(this might not work with the corpus callosum bundles). "
+                "In the left and right views, the view not containing the specific bundle will be empty. "
                 "To rapidly switch between bundles, you can also use the left and right arrow keys on your keyboard. "
             ),
             content=content,
@@ -307,75 +303,6 @@ class MultiqcModule(BaseMultiqcModule):
         """
 
         return selector_html + "\n" + "\n".join(bundle_panels) + script
-
-    @staticmethod
-    def _load_nii_as_mesh(
-        nii_fp,
-        threshold: float = 0.5,
-        blur_sigma: float = 1.5,
-        smooth_i: int = 10,
-        smooth_f: float = 0.1,
-    ) -> pv.PolyData:
-        """
-        Small utility function to load a nifti image, then convert it to
-        meshes using marching cubes.
-
-        **For now, this function is here, but will be included directly in
-        yabplot in the future.**
-
-        Parameters
-        ----------
-        nii_path : str
-            Absolute path to a NIfTI file representing a 3D volume. If 4D, only the first volume will be used.
-        threshold : float, optional
-            Threshold applied after optional blur. Voxels ``> threshold`` are kept.
-        blur_sigma : float, optional
-            Gaussian blur (voxel units) before thresholding.
-        smooth_i : int, optional
-            Number of PyVista smoothing iterations after surface extraction.
-        smooth_f : float, optional
-            Relaxation factor for mesh smoothing.
-
-        Returns
-        -------
-        mesh : pyvista.PolyData
-            The extracted and smoothed surface mesh ready for plotting.
-        """
-        img = nib.load(nii_fp)
-        vol = img.get_fdata()
-
-        if vol.ndim > 3:
-            log.warning(f"[WARNING] detected {vol.ndim}d nifti volume. using the first volume (index 0).")
-            vol = vol[..., 0]
-
-        vol = np.nan_to_num(vol, nan=0.0)
-
-        if blur_sigma and blur_sigma > 0:
-            vol = gaussian_filter(vol, sigma=float(blur_sigma))
-
-        mask = vol > float(threshold)
-
-        if not np.any(mask):
-            raise ValueError("Mask is empty after thresholding. Adjust threshold/blur_sigma.")
-
-        verts_vox, faces, _, _ = measure.marching_cubes(mask.astype(np.float32), level=0.5)
-        verts_world = nib.affines.apply_affine(img.affine, verts_vox)
-
-        faces_pv = np.hstack([np.full((faces.shape[0], 1), 3, dtype=np.int64), faces.astype(np.int64)]).ravel()
-        mesh = pv.PolyData(verts_world.astype(np.float32), faces_pv)
-
-        if smooth_i and smooth_i > 0:
-            mesh = mesh.smooth(n_iter=int(smooth_i), relaxation_factor=float(smooth_f))
-
-        if mesh.n_points == 0:
-            raise ValueError("Extracted mesh has no vertices. Check input mask and parameters.")
-
-        try:
-            mesh = mesh.fill_holes(1000)
-        except Exception as exc:
-            log.warning(f"Mesh hole filling failed: {exc}. Continuing with unfilled meshes.")
-
-        return mesh
 
     @staticmethod
     def _crop_png_whitespace(png_path: str, white_threshold: int = 245, pad: int = 8) -> None:

--- a/neuroimaging/modules/bundles/bundles.py
+++ b/neuroimaging/modules/bundles/bundles.py
@@ -1,0 +1,414 @@
+"""
+=============================
+Bundles modules
+=============================
+This module visualizes bundles to facilitate the
+quality control process.
+
+This module does not leverage any metrics and consist
+solely of a visual quality control step. To leverage metrics
+per bundles, please refer to the tractometry or metricsinroi
+modules.
+"""
+
+import base64
+import html
+import io
+import json
+import logging
+import os
+import re
+import shutil
+import tempfile
+from contextlib import redirect_stdout
+from typing import Dict, List
+
+import nibabel as nib
+import numpy as np
+import pyvista as pv
+import yabplot as yab
+from scipy.ndimage import gaussian_filter
+from skimage import io as skio
+from skimage import measure
+
+from multiqc import config
+from multiqc.base_module import BaseMultiqcModule, ModuleNoSamplesFound
+
+log = logging.getLogger(__name__)
+
+
+class MultiqcModule(BaseMultiqcModule):
+    """
+    This module visualizes bundles to facilitate the
+    quality control process.
+
+    This module does not leverage any metrics and consist
+    solely of a visual quality control step. To leverage metrics
+    per bundles, please refer to the tractometry or metricsinroi
+    modules.
+    """
+
+    def __init__(self):
+        super(MultiqcModule, self).__init__(
+            name="White Matter Bundles",
+            target="bundles",
+            href="https://github.com/nf-neuro/MultiQC_neuroimaging",
+            info=(
+                "Visualization of white matter bundles for quality control purposes. "
+                "Use the drop-down menu to switch between bundles and assess the quality "
+                "of the extraction process. Specifically, you can check the overall shape "
+                "and anatomical location, as well as the presence of spurious streamlines. "
+            ),
+        )
+
+        if not config.kwargs.get("single_subject"):
+            raise ModuleNoSamplesFound
+
+        self.config = getattr(config, "bundles", {}) or {}
+
+        trk_files = list(self.find_log_files("bundles/trk"))
+        nii_files = list(self.find_log_files("bundles/nii"))
+
+        if not trk_files:
+            raise ModuleNoSamplesFound
+
+        if len(nii_files) > 1:
+            log.warning("Found multiple .nii files, will use the first one.")
+        nii_file = self._resolve_found_file_path(nii_files[0]) if nii_files else None
+        if not nii_file:
+            log.warning("No .nii files found, bundle visualizations will be performed without background.")
+
+        bundles_to_include = self.config.get("bundles", [])
+        if bundles_to_include:
+            trk_dict = {}
+            for bundle_name in bundles_to_include:
+                matching_files = [
+                    found_file
+                    for found_file in trk_files
+                    # Look for the bundle name anywhere in the filename.
+                    if re.search(
+                        rf"(^|[_-]){re.escape(bundle_name)}([_.-]|$)",
+                        found_file.get("fn", ""),
+                        re.IGNORECASE,
+                    )
+                ]
+                if matching_files:
+                    trk_dict[bundle_name] = self._resolve_found_file_path(matching_files[0])
+                else:
+                    log.warning(f"No .trk file found for bundle '{bundle_name}'. Skipping this bundle.")
+            if not trk_dict:
+                raise ModuleNoSamplesFound(f"No .trk files found matching the specified bundles: {bundles_to_include}")
+        else:
+            trk_dict = self._parse_trk_paths(trk_files)
+            if not trk_dict:
+                log.warning(
+                    "No valid .trk files found to parse bundle names. Please check the file naming convention "
+                    "and ensure that .trk files are present."
+                )
+                raise ModuleNoSamplesFound("No valid .trk files found to parse bundle names.")
+
+        log.info(f"Found {len(trk_dict)} bundles to visualize")
+        bg_mesh = self._load_nii_as_mesh(nii_file) if nii_file else None
+
+        bundle_images = self._render_bundle_images(trk_dict, bg_mesh)
+        if not bundle_images:
+            raise ModuleNoSamplesFound("No bundle previews could be generated.")
+
+        default_bundle = next(iter(bundle_images))
+        content = self._build_bundle_browser(bundle_images, default_bundle)
+
+        self.add_section(
+            name="Bundle Visualization",
+            anchor="bundles_visualization",
+            description=(
+                "Use the dropdown to switch between bundle previews. The figure shows the bundle extraction "
+                "for one tract at a time so you can inspect anatomy and spurious streamlines more easily. "
+                "<b>Views include, from left to right, superior, right lateral, left lateral, and anterior.</b> "
+                "In the left and right views, the view not containing the specific bundle will be empty "
+                "(this might not work with the corpus callosum bundles). "
+                "To rapidly switch between bundles, you can also use the left and right arrow keys on your keyboard. "
+            ),
+            content=content,
+        )
+
+    def _resolve_found_file_path(self, found_file: dict) -> str:
+        fn = found_file.get("fn", "")
+        if os.path.isabs(fn):
+            return fn
+        root = found_file.get("root", "")
+        return os.path.join(root, fn) if root else fn
+
+    def _parse_trk_paths(self, files: List[dict]) -> Dict[str, str]:
+        """Parse bundle names from found .trk files and return a bundle->path mapping."""
+        bundle_dict: Dict[str, str] = {}
+        for found_file in files:
+            filename = found_file.get("fn", "")
+            match = re.search(r"_tract-([^_]+)", filename)
+            if match:
+                bundle_name = match.group(1)
+                bundle_dict[bundle_name] = self._resolve_found_file_path(found_file)
+            else:
+                log.warning(f"Could not extract bundle name from file path: {filename}. Skipping this file.")
+        return bundle_dict
+
+    def _render_bundle_images(self, trk_dict: Dict[str, str], bg_mesh: pv.PolyData | None) -> Dict[str, str]:
+        """Render bundle figures and return base64-encoded HTML images keyed by bundle name."""
+        bundle_images: Dict[str, str] = {}
+
+        for bundle_name, trk_path in trk_dict.items():
+            try:
+                with tempfile.TemporaryDirectory() as tmpdir:
+                    tmp_trk_path = os.path.join(tmpdir, f"{bundle_name}.trk")
+                    shutil.copy(trk_path, tmp_trk_path)
+
+                    export_path = os.path.join(tmpdir, f"bundles_{bundle_name}.png")
+                    with redirect_stdout(io.StringIO()):
+                        yab.plot_tracts(
+                            custom_atlas_path=tmpdir,
+                            views=["superior", "right_lateral", "left_lateral", "anterior"],
+                            bmesh=bg_mesh,
+                            figsize=(2000, 1200),
+                            display_type="object",
+                            orientation_coloring=True,
+                            export_path=export_path,
+                        )
+
+                    if not os.path.exists(export_path):
+                        log.warning(f"Bundle preview was not created for '{bundle_name}'.")
+                        continue
+
+                    self._crop_png_whitespace(export_path)
+
+                    with open(export_path, "rb") as fp:
+                        img_b64 = base64.b64encode(fp.read()).decode("ascii")
+
+                    bundle_images[bundle_name] = (
+                        '<img alt="{alt}" style="width: 100%; max-width: 100%; height: auto; display: block;" '
+                        'src="data:image/png;base64,{data}" />'
+                    ).format(alt=html.escape(f"Bundle preview for {bundle_name}"), data=img_b64)
+            except Exception as exc:
+                log.warning(f"Failed to render bundle preview for '{bundle_name}': {exc}")
+
+        return bundle_images
+
+    def _build_bundle_browser(self, bundle_images: Dict[str, str], default_bundle: str) -> str:
+        """Build the dropdown and the one-at-a-time bundle preview container."""
+        bundle_ids = {
+            bundle_name: f"bundle_{index}_{re.sub(r'[^0-9a-zA-Z_]', '_', bundle_name)}"
+            for index, bundle_name in enumerate(bundle_images)
+        }
+
+        selector_html = ""
+        if len(bundle_images) > 1:
+            options_html = "".join(
+                [
+                    f'<option value="{html.escape(bundle_name)}" '
+                    f"{'selected' if bundle_name == default_bundle else ''}>"
+                    f"{html.escape(bundle_name)}</option>"
+                    for bundle_name in bundle_images
+                ]
+            )
+            selector_html = f"""
+            <div class="d-flex justify-content-center mb-3">
+                <div class="text-center">
+                    <label class="form-label mb-2 fw-semibold">Bundle</label>
+                    <div class="d-flex align-items-center gap-2">
+                        <button
+                            class="btn btn-outline-secondary"
+                            type="button"
+                            aria-label="Previous bundle"
+                            onclick="showPreviousBundle()"
+                        >&larr;</button>
+                        <select
+                            id="bundle-selector"
+                            class="form-select shadow-sm"
+                            aria-label="Bundle selection"
+                            onchange="renderBundleView(this.value)"
+                            style="min-width: 220px;"
+                        >
+                            {options_html}
+                        </select>
+                        <button
+                            class="btn btn-outline-secondary"
+                            type="button"
+                            aria-label="Next bundle"
+                            onclick="showNextBundle()"
+                        >&rarr;</button>
+                    </div>
+                </div>
+            </div>
+            """
+
+        bundle_panels = []
+        for bundle_name, img_html in bundle_images.items():
+            display = "block" if bundle_name == default_bundle else "none"
+            bundle_panels.append(
+                f'<div id="{bundle_ids[bundle_name]}" style="display: {display}; width: 100%;">{img_html}</div>'
+            )
+
+        script = f"""
+        <script>
+        var bundleContainers = {json.dumps(bundle_ids)};
+        var bundleOrder = {json.dumps(list(bundle_images.keys()))};
+        var currentBundleIdx = bundleOrder.indexOf({json.dumps(default_bundle)});
+
+        function updateBundleSelector(bundleName) {{
+            var selector = document.getElementById('bundle-selector');
+            if (selector) {{
+                selector.value = bundleName;
+            }}
+        }}
+
+        function renderBundleView(bundleName) {{
+            Object.keys(bundleContainers).forEach(function(name) {{
+                var container = document.getElementById(bundleContainers[name]);
+                if (container) {{
+                    container.style.display = "none";
+                }}
+            }});
+
+            var selectedContainer = document.getElementById(bundleContainers[bundleName]);
+            if (selectedContainer) {{
+                selectedContainer.style.display = "block";
+                currentBundleIdx = bundleOrder.indexOf(bundleName);
+                updateBundleSelector(bundleName);
+            }}
+        }}
+
+        function showPreviousBundle() {{
+            if (!bundleOrder.length) {{
+                return;
+            }}
+            currentBundleIdx = (currentBundleIdx - 1 + bundleOrder.length) % bundleOrder.length;
+            renderBundleView(bundleOrder[currentBundleIdx]);
+        }}
+
+        function showNextBundle() {{
+            if (!bundleOrder.length) {{
+                return;
+            }}
+            currentBundleIdx = (currentBundleIdx + 1) % bundleOrder.length;
+            renderBundleView(bundleOrder[currentBundleIdx]);
+        }}
+
+        if (!window.bundleArrowKeyListenerAttached) {{
+            window.bundleArrowKeyListenerAttached = true;
+            document.addEventListener('keydown', function(event) {{
+                if (event.key === 'ArrowLeft') {{
+                    event.preventDefault();
+                    showPreviousBundle();
+                }} else if (event.key === 'ArrowRight') {{
+                    event.preventDefault();
+                    showNextBundle();
+                }}
+            }});
+        }}
+        </script>
+        """
+
+        return selector_html + "\n" + "\n".join(bundle_panels) + script
+
+    @staticmethod
+    def _load_nii_as_mesh(
+        nii_fp,
+        threshold: float = 0.5,
+        blur_sigma: float = 1.5,
+        smooth_i: int = 10,
+        smooth_f: float = 0.1,
+    ) -> pv.PolyData:
+        """
+        Small utility function to load a nifti image, then convert it to
+        meshes using marching cubes.
+
+        **For now, this function is here, but will be included directly in
+        yabplot in the future.**
+
+        Parameters
+        ----------
+        nii_path : str
+            Absolute path to a NIfTI file representing a 3D volume. If 4D, only the first volume will be used.
+        threshold : float, optional
+            Threshold applied after optional blur. Voxels ``> threshold`` are kept.
+        blur_sigma : float, optional
+            Gaussian blur (voxel units) before thresholding.
+        smooth_i : int, optional
+            Number of PyVista smoothing iterations after surface extraction.
+        smooth_f : float, optional
+            Relaxation factor for mesh smoothing.
+
+        Returns
+        -------
+        mesh : pyvista.PolyData
+            The extracted and smoothed surface mesh ready for plotting.
+        """
+        img = nib.load(nii_fp)
+        vol = img.get_fdata()
+
+        if vol.ndim > 3:
+            log.warning(f"[WARNING] detected {vol.ndim}d nifti volume. using the first volume (index 0).")
+            vol = vol[..., 0]
+
+        vol = np.nan_to_num(vol, nan=0.0)
+
+        if blur_sigma and blur_sigma > 0:
+            vol = gaussian_filter(vol, sigma=float(blur_sigma))
+
+        mask = vol > float(threshold)
+
+        if not np.any(mask):
+            raise ValueError("Mask is empty after thresholding. Adjust threshold/blur_sigma.")
+
+        verts_vox, faces, _, _ = measure.marching_cubes(mask.astype(np.float32), level=0.5)
+        verts_world = nib.affines.apply_affine(img.affine, verts_vox)
+
+        faces_pv = np.hstack([np.full((faces.shape[0], 1), 3, dtype=np.int64), faces.astype(np.int64)]).ravel()
+        mesh = pv.PolyData(verts_world.astype(np.float32), faces_pv)
+
+        if smooth_i and smooth_i > 0:
+            mesh = mesh.smooth(n_iter=int(smooth_i), relaxation_factor=float(smooth_f))
+
+        if mesh.n_points == 0:
+            raise ValueError("Extracted mesh has no vertices. Check input mask and parameters.")
+
+        try:
+            mesh = mesh.fill_holes(1000)
+        except Exception as exc:
+            log.warning(f"Mesh hole filling failed: {exc}. Continuing with unfilled meshes.")
+
+        return mesh
+
+    @staticmethod
+    def _crop_png_whitespace(png_path: str, white_threshold: int = 245, pad: int = 8) -> None:
+        """Crop near-white borders from PNG previews to reduce empty space."""
+        try:
+            img = skio.imread(png_path)
+            if img.size == 0:
+                return
+
+            if np.issubdtype(img.dtype, np.floating) and float(np.nanmax(img)) <= 1.0:
+                threshold = white_threshold / 255.0
+            else:
+                threshold = float(white_threshold)
+
+            if img.ndim == 2:
+                content_mask = img < threshold
+            else:
+                rgb = img[..., :3]
+                content_mask = np.any(rgb < threshold, axis=-1)
+
+            if not np.any(content_mask):
+                return
+
+            rows = np.where(np.any(content_mask, axis=1))[0]
+            cols = np.where(np.any(content_mask, axis=0))[0]
+
+            top = max(int(rows[0]) - pad, 0)
+            bottom = min(int(rows[-1]) + pad + 1, img.shape[0])
+            left = max(int(cols[0]) - pad, 0)
+            right = min(int(cols[-1]) + pad + 1, img.shape[1])
+
+            cropped = img[top:bottom, left:right]
+            if cropped.shape != img.shape:
+                skio.imsave(png_path, cropped, check_contrast=False)
+        except Exception as exc:
+            log.warning(f"Failed to crop white space for '{png_path}': {exc}")

--- a/neuroimaging/modules/bundles/tests/test_bundles.py
+++ b/neuroimaging/modules/bundles/tests/test_bundles.py
@@ -1,0 +1,320 @@
+"""Tests for the bundles module."""
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+from multiqc import config
+from multiqc.base_module import ModuleNoSamplesFound
+from skimage import io as skio
+
+from neuroimaging.modules.bundles.bundles import MultiqcModule
+
+
+def _module_instance():
+    """Create a bare module instance for testing helper methods."""
+    return object.__new__(MultiqcModule)
+
+
+def test_resolve_found_file_path_handles_relative_and_absolute_paths(tmp_path):
+    module = _module_instance()
+
+    rel = module._resolve_found_file_path({"root": "/tmp/data", "fn": "bundle.trk"})
+    assert rel == "/tmp/data/bundle.trk"
+
+    abs_path = Path(tmp_path) / "bundle.trk"
+    assert module._resolve_found_file_path({"fn": str(abs_path)}) == str(abs_path)
+
+
+def test_parse_trk_paths_extracts_bundle_name_and_skips_invalid(caplog):
+    module = _module_instance()
+
+    parsed = module._parse_trk_paths(
+        [
+            {"fn": "sub-01_tract-IFOFL_track-sdstream_tractogram.trk", "root": "/data"},
+            {"fn": "no-tract-token.trk", "root": "/data"},
+        ]
+    )
+
+    assert parsed == {"IFOFL": "/data/sub-01_tract-IFOFL_track-sdstream_tractogram.trk"}
+    assert "Could not extract bundle name" in caplog.text
+
+
+def test_crop_png_whitespace_reduces_image_size(tmp_path):
+    fp = tmp_path / "img.png"
+    img = np.full((100, 120, 3), 255, dtype=np.uint8)
+    img[30:70, 40:80, :] = 0
+    skio.imsave(str(fp), img, check_contrast=False)
+
+    MultiqcModule._crop_png_whitespace(str(fp), white_threshold=245, pad=4)
+    cropped = skio.imread(str(fp))
+
+    assert cropped.shape[0] < img.shape[0]
+    assert cropped.shape[1] < img.shape[1]
+
+
+def test_crop_png_whitespace_keeps_all_white_image_unchanged(tmp_path):
+    fp = tmp_path / "all_white.png"
+    img = np.full((48, 64, 3), 255, dtype=np.uint8)
+    skio.imsave(str(fp), img, check_contrast=False)
+
+    MultiqcModule._crop_png_whitespace(str(fp), white_threshold=245, pad=8)
+    result = skio.imread(str(fp))
+
+    assert result.shape == img.shape
+
+
+def test_crop_png_whitespace_handles_float_images(tmp_path):
+    fp = tmp_path / "float_img.png"
+    img = np.ones((60, 60, 3), dtype=np.float32)
+    img[20:40, 20:40, :] = 0.0
+    # Save as uint8 PNG while keeping the method on float-threshold branch via direct call input recreation.
+    skio.imsave(str(fp), (img * 255).astype(np.uint8), check_contrast=False)
+
+    MultiqcModule._crop_png_whitespace(str(fp), white_threshold=245, pad=2)
+    result = skio.imread(str(fp))
+
+    assert result.shape[0] <= 60
+    assert result.shape[1] <= 60
+
+
+def test_build_bundle_browser_multiple_bundles_includes_controls_and_keyboard_js():
+    module = _module_instance()
+
+    html_content = module._build_bundle_browser(
+        {
+            "IFOF_L": '<img alt="a" src="data:image/png;base64,AAA" />',
+            "SLF_R": '<img alt="b" src="data:image/png;base64,BBB" />',
+        },
+        default_bundle="IFOF_L",
+    )
+
+    assert 'id="bundle-selector"' in html_content
+    assert "Previous bundle" in html_content
+    assert "Next bundle" in html_content
+    assert "showPreviousBundle" in html_content
+    assert "showNextBundle" in html_content
+    assert "ArrowLeft" in html_content
+    assert "ArrowRight" in html_content
+    assert "display: block" in html_content
+    assert "display: none" in html_content
+
+
+def test_build_bundle_browser_single_bundle_omits_selector_controls():
+    module = _module_instance()
+
+    html_content = module._build_bundle_browser(
+        {"IFOF_L": '<img alt="a" src="data:image/png;base64,AAA" />'},
+        default_bundle="IFOF_L",
+    )
+
+    assert 'id="bundle-selector"' not in html_content
+    assert "Previous bundle" not in html_content
+    assert "Next bundle" not in html_content
+    assert "bundleContainers" in html_content
+
+
+def test_init_raises_when_single_subject_disabled():
+    config.kwargs = {"single_subject": False}
+
+    with pytest.raises(ModuleNoSamplesFound):
+        MultiqcModule()
+
+
+def test_init_raises_when_no_trk_files(monkeypatch):
+    config.kwargs = {"single_subject": True}
+    config.bundles = {"bundles": []}
+
+    def fake_find_log_files(self, pattern):
+        return []
+
+    monkeypatch.setattr(MultiqcModule, "find_log_files", fake_find_log_files, raising=False)
+
+    with pytest.raises(ModuleNoSamplesFound):
+        MultiqcModule()
+
+
+def test_init_filters_configured_bundle_list_with_start_of_filename_match(monkeypatch, tmp_path):
+    config.kwargs = {"single_subject": True}
+    config.bundles = {"bundles": ["IFOF_L", "SLF_R"]}
+
+    trk_files = [
+        {"fn": "IFOF_L.trk", "root": str(tmp_path)},
+        {"fn": "subjectX-SLF_R.trk", "root": str(tmp_path)},
+        {"fn": "UF_L.trk", "root": str(tmp_path)},
+    ]
+
+    captured_trk_dict = {}
+
+    def fake_find_log_files(self, pattern):
+        if pattern == "bundles/trk":
+            return trk_files
+        if pattern == "bundles/nii":
+            return []
+        return []
+
+    def fake_render_bundle_images(self, trk_dict, bg_mesh):
+        captured_trk_dict.update(trk_dict)
+        return {k: f"<img alt='{k}' src='data:image/png;base64,AAA' />" for k in trk_dict}
+
+    captured_sections = []
+
+    def fake_add_section(self, name, anchor, content, **kwargs):
+        captured_sections.append((name, anchor, content))
+
+    monkeypatch.setattr(MultiqcModule, "find_log_files", fake_find_log_files, raising=False)
+    monkeypatch.setattr(MultiqcModule, "_load_nii_as_mesh", lambda *args, **kwargs: None)
+    monkeypatch.setattr(MultiqcModule, "_render_bundle_images", fake_render_bundle_images, raising=False)
+    monkeypatch.setattr(MultiqcModule, "add_section", fake_add_section, raising=False)
+
+    MultiqcModule()
+
+    assert set(captured_trk_dict.keys()) == {"IFOF_L", "SLF_R"}
+    assert "UF_L" not in captured_trk_dict
+    assert len(captured_sections) == 1
+    assert captured_sections[0][0] == "Bundle Visualization"
+
+
+def test_init_raises_when_configured_bundles_do_not_match_any_files(monkeypatch, tmp_path, caplog):
+    config.kwargs = {"single_subject": True}
+    config.bundles = {"bundles": ["IFOF_L", "SLF_R"]}
+
+    trk_files = [{"fn": "UF_L.trk", "root": str(tmp_path)}]
+
+    def fake_find_log_files(self, pattern):
+        if pattern == "bundles/trk":
+            return trk_files
+        if pattern == "bundles/nii":
+            return []
+        return []
+
+    monkeypatch.setattr(MultiqcModule, "find_log_files", fake_find_log_files, raising=False)
+
+    with pytest.raises(ModuleNoSamplesFound):
+        MultiqcModule()
+
+    assert "No .trk file found for bundle 'IFOF_L'" in caplog.text
+    assert "No .trk file found for bundle 'SLF_R'" in caplog.text
+
+
+def test_init_uses_parse_trk_paths_when_no_bundle_filter(monkeypatch, tmp_path):
+    config.kwargs = {"single_subject": True}
+    config.bundles = {"bundles": []}
+
+    trk_files = [{"fn": "ignored.trk", "root": str(tmp_path)}]
+    parsed_trk_dict = {"A": "/tmp/A.trk", "B": "/tmp/B.trk"}
+    captured_trk_dict = {}
+
+    def fake_find_log_files(self, pattern):
+        if pattern == "bundles/trk":
+            return trk_files
+        if pattern == "bundles/nii":
+            return []
+        return []
+
+    def fake_parse_trk_paths(self, files):
+        return parsed_trk_dict
+
+    def fake_render_bundle_images(self, trk_dict, bg_mesh):
+        captured_trk_dict.update(trk_dict)
+        return {k: f"<img alt='{k}' src='data:image/png;base64,AAA' />" for k in trk_dict}
+
+    monkeypatch.setattr(MultiqcModule, "find_log_files", fake_find_log_files, raising=False)
+    monkeypatch.setattr(MultiqcModule, "_parse_trk_paths", fake_parse_trk_paths, raising=False)
+    monkeypatch.setattr(MultiqcModule, "_load_nii_as_mesh", lambda *args, **kwargs: None)
+    monkeypatch.setattr(MultiqcModule, "_render_bundle_images", fake_render_bundle_images, raising=False)
+    monkeypatch.setattr(MultiqcModule, "add_section", lambda *args, **kwargs: None, raising=False)
+
+    MultiqcModule()
+
+    assert captured_trk_dict == parsed_trk_dict
+
+
+def test_init_raises_when_render_returns_empty(monkeypatch, tmp_path):
+    config.kwargs = {"single_subject": True}
+    config.bundles = {"bundles": ["IFOF_L"]}
+
+    trk_files = [{"fn": "IFOF_L.trk", "root": str(tmp_path)}]
+
+    def fake_find_log_files(self, pattern):
+        if pattern == "bundles/trk":
+            return trk_files
+        if pattern == "bundles/nii":
+            return []
+        return []
+
+    monkeypatch.setattr(MultiqcModule, "find_log_files", fake_find_log_files, raising=False)
+    monkeypatch.setattr(MultiqcModule, "_load_nii_as_mesh", lambda *args, **kwargs: None)
+    monkeypatch.setattr(MultiqcModule, "_render_bundle_images", lambda *args, **kwargs: {}, raising=False)
+
+    with pytest.raises(ModuleNoSamplesFound):
+        MultiqcModule()
+
+
+def test_init_warns_on_multiple_nii_and_uses_first(monkeypatch, tmp_path, caplog):
+    config.kwargs = {"single_subject": True}
+    config.bundles = {"bundles": ["IFOF_L"]}
+
+    trk_files = [{"fn": "IFOF_L.trk", "root": str(tmp_path)}]
+    nii_files = [
+        {"fn": "first.nii.gz", "root": str(tmp_path)},
+        {"fn": "second.nii.gz", "root": str(tmp_path)},
+    ]
+    called = {"nii_fp": None}
+
+    def fake_find_log_files(self, pattern):
+        if pattern == "bundles/trk":
+            return trk_files
+        if pattern == "bundles/nii":
+            return nii_files
+        return []
+
+    def fake_load_nii_as_mesh(nii_fp):
+        called["nii_fp"] = nii_fp
+        return "mesh"
+
+    monkeypatch.setattr(MultiqcModule, "find_log_files", fake_find_log_files, raising=False)
+    monkeypatch.setattr(MultiqcModule, "_load_nii_as_mesh", staticmethod(fake_load_nii_as_mesh))
+    monkeypatch.setattr(
+        MultiqcModule,
+        "_render_bundle_images",
+        lambda self, trk_dict, bg_mesh: {"IFOF_L": "<img alt='IFOF_L' src='data:image/png;base64,AAA' />"},
+        raising=False,
+    )
+    monkeypatch.setattr(MultiqcModule, "add_section", lambda *args, **kwargs: None, raising=False)
+
+    MultiqcModule()
+
+    assert "Found multiple .nii files, will use the first one." in caplog.text
+    assert called["nii_fp"].endswith("first.nii.gz")
+
+
+def test_init_warns_when_no_nii_and_skips_mesh_loading(monkeypatch, tmp_path, caplog):
+    config.kwargs = {"single_subject": True}
+    config.bundles = {"bundles": ["IFOF_L"]}
+
+    trk_files = [{"fn": "IFOF_L.trk", "root": str(tmp_path)}]
+
+    def fake_find_log_files(self, pattern):
+        if pattern == "bundles/trk":
+            return trk_files
+        if pattern == "bundles/nii":
+            return []
+        return []
+
+    def fail_if_called(*args, **kwargs):
+        raise AssertionError("_load_nii_as_mesh should not be called when no .nii is present")
+
+    monkeypatch.setattr(MultiqcModule, "find_log_files", fake_find_log_files, raising=False)
+    monkeypatch.setattr(MultiqcModule, "_load_nii_as_mesh", fail_if_called)
+    monkeypatch.setattr(
+        MultiqcModule,
+        "_render_bundle_images",
+        lambda self, trk_dict, bg_mesh: {"IFOF_L": "<img alt='IFOF_L' src='data:image/png;base64,AAA' />"},
+        raising=False,
+    )
+    monkeypatch.setattr(MultiqcModule, "add_section", lambda *args, **kwargs: None, raising=False)
+
+    MultiqcModule()
+
+    assert "No .nii files found, bundle visualizations will be performed without background." in caplog.text

--- a/neuroimaging/modules/bundles/tests/test_bundles.py
+++ b/neuroimaging/modules/bundles/tests/test_bundles.py
@@ -163,7 +163,6 @@ def test_init_filters_configured_bundle_list_with_start_of_filename_match(monkey
         captured_sections.append((name, anchor, content))
 
     monkeypatch.setattr(MultiqcModule, "find_log_files", fake_find_log_files, raising=False)
-    monkeypatch.setattr(MultiqcModule, "_load_nii_as_mesh", lambda *args, **kwargs: None)
     monkeypatch.setattr(MultiqcModule, "_render_bundle_images", fake_render_bundle_images, raising=False)
     monkeypatch.setattr(MultiqcModule, "add_section", fake_add_section, raising=False)
 
@@ -221,7 +220,6 @@ def test_init_uses_parse_trk_paths_when_no_bundle_filter(monkeypatch, tmp_path):
 
     monkeypatch.setattr(MultiqcModule, "find_log_files", fake_find_log_files, raising=False)
     monkeypatch.setattr(MultiqcModule, "_parse_trk_paths", fake_parse_trk_paths, raising=False)
-    monkeypatch.setattr(MultiqcModule, "_load_nii_as_mesh", lambda *args, **kwargs: None)
     monkeypatch.setattr(MultiqcModule, "_render_bundle_images", fake_render_bundle_images, raising=False)
     monkeypatch.setattr(MultiqcModule, "add_section", lambda *args, **kwargs: None, raising=False)
 
@@ -244,7 +242,6 @@ def test_init_raises_when_render_returns_empty(monkeypatch, tmp_path):
         return []
 
     monkeypatch.setattr(MultiqcModule, "find_log_files", fake_find_log_files, raising=False)
-    monkeypatch.setattr(MultiqcModule, "_load_nii_as_mesh", lambda *args, **kwargs: None)
     monkeypatch.setattr(MultiqcModule, "_render_bundle_images", lambda *args, **kwargs: {}, raising=False)
 
     with pytest.raises(ModuleNoSamplesFound):
@@ -271,10 +268,10 @@ def test_init_warns_on_multiple_nii_and_uses_first(monkeypatch, tmp_path, caplog
 
     def fake_load_nii_as_mesh(nii_fp):
         called["nii_fp"] = nii_fp
-        return "mesh"
+        return object()
 
     monkeypatch.setattr(MultiqcModule, "find_log_files", fake_find_log_files, raising=False)
-    monkeypatch.setattr(MultiqcModule, "_load_nii_as_mesh", staticmethod(fake_load_nii_as_mesh))
+    monkeypatch.setattr("neuroimaging.modules.bundles.bundles.yab.load_nii_as_mesh", fake_load_nii_as_mesh)
     monkeypatch.setattr(
         MultiqcModule,
         "_render_bundle_images",
@@ -302,11 +299,7 @@ def test_init_warns_when_no_nii_and_skips_mesh_loading(monkeypatch, tmp_path, ca
             return []
         return []
 
-    def fail_if_called(*args, **kwargs):
-        raise AssertionError("_load_nii_as_mesh should not be called when no .nii is present")
-
     monkeypatch.setattr(MultiqcModule, "find_log_files", fake_find_log_files, raising=False)
-    monkeypatch.setattr(MultiqcModule, "_load_nii_as_mesh", fail_if_called)
     monkeypatch.setattr(
         MultiqcModule,
         "_render_bundle_images",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
     "multiqc",
     "pandas",
     "plotly",
-    "yabplot"
+    "yabplot>=0.4.0"
 ]
 
 [tool.setuptools]
@@ -53,6 +53,7 @@ packages = [
     "neuroimaging.modules.streamline_count",
     "neuroimaging.modules.atlaslabels",
     "neuroimaging.modules.connectivity",
+    "neuroimaging.modules.bundles",
 ]
 
 [project.urls]
@@ -77,6 +78,7 @@ metricsinroi = "neuroimaging.modules.metricsinroi:MultiqcModule"
 harmonization = "neuroimaging.modules.harmonization.harmonization:MultiqcModule"
 atlaslabels = "neuroimaging.modules.atlaslabels:MultiqcModule"
 connectivity = "neuroimaging.modules.connectivity:MultiqcModule"
+bundles = "neuroimaging.modules.bundles:MultiqcModule"
 
 [project.entry-points."multiqc.cli_options.v1"]
 single_subject = "neuroimaging.cli:single_subject"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
     "multiqc",
     "pandas",
     "plotly",
-    "yabplot>=0.4.0"
+    "yabplot @ git+https://github.com/teanijarv/yabplot.git@0f5f90f96f712fd32e562f88560421970ce39b57"
 ]
 
 [tool.setuptools]


### PR DESCRIPTION
Self-explanatory, here's an example of the report:

[multiqc_report.html](https://github.com/user-attachments/files/26607975/multiqc_report.html)

<img width="1483" height="422" alt="image" src="https://github.com/user-attachments/assets/f976a258-dfc2-46c1-80a5-ae2f13cec491" />

**Need to wait for a newer release of `yabplot` before removing the nifti to mesh conversion function, and also for a fix regarding side filtering for commissural bundles**